### PR TITLE
SPEC-84 sign the speckle structural suite installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,15 @@ jobs:
       - name: create Installer
         run: iscc /dAppVersion="${{ steps.calculate-tag-version.outputs.tag }}" SpeckleStructuralSuiteInstaller.iss
 
+      - name: Get Signing Certificate
+        run: |
+          [IO.File]::WriteAllBytes('signing.pfx', [Convert]::FromBase64String("${{ secrets.SIGNING_CERT }}"))
+
+      - name: Sign Installer
+        run: |
+          Set-Alias signtool "C:/Program Files (x86)/Windows Kits/10/bin/10.0.18362.0/x64/signtool.exe"
+          signtool sign /v /f signing.pfx /p "${{ secrets.SIGNING_CERT_PASSWORD }}" /fd sha256 /tr http://rfc3161timestamp.globalsign.com/advanced /td sha256 /d SpeckleStructuralSuite SpeckleStructuralSuite.exe
+
       - name: Create Release
         id: create-release
         uses: actions/create-release@latest


### PR DESCRIPTION
Sign the installer so it is trusted when installed on users machines and they will no longer get the warning about an untrusted source.

Using the Oasys `pfx` cert. This is stored in GitHub secrets encoded with Base64 and retrieved in the pipeline.

The installer should only be signed in the workflow not locally.

You can see the signed installer in a test run I did here: https://github.com/arup-group/specklestructuralsuite-installer/actions/runs/264123078

@nic-burgers-arup let me know if you are happy to review this change.